### PR TITLE
TOOL-21483 upgrade rust tools to 1.70.0

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ DEB_HOST_GNU_CPU ?= $(shell dpkg-architecture -qDEB_HOST_GNU_CPU)
 	dh $@
 
 override_dh_install:
-	./scripts/fetch-and-run-installer.sh "1.66.0" "/usr" "debian/tmp" $(DEB_HOST_GNU_CPU)
+	./scripts/fetch-and-run-installer.sh "1.70.0" "/usr" "debian/tmp" $(DEB_HOST_GNU_CPU)
 
 	dh_install --autodest "debian/tmp/*"
 


### PR DESCRIPTION
For posterity's sake, the process I use to update rust is the following:

1. I download the Rust artifacts from the official rust release, [here](https://forge.rust-lang.org/infra/other-installation-methods.html#standalone-installers)
a) i.e. I download both the `tar.gz` and `tar.gz.asc` files of the `x86_64-unknown-linux-gnu` "flavor"
2. Then I "deploy" these files to artifactory, using [this](https://artifactory.delphix.com/ui/repos/tree/General/linux-pkg%2Frust) directory; e.g. we can see all the uploads we've done so far:
![image](https://user-images.githubusercontent.com/658081/164287800-42426611-008c-45e3-b989-34f9ec28cdae.png)
3. Finally, I open the PR, verify the build works (it consumes the files deployed in step 2), then land it.
