### PR TITLE
TOOL-27106 Upgrade rust tools to 1.83.0

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ DEB_HOST_GNU_CPU ?= $(shell dpkg-architecture -qDEB_HOST_GNU_CPU)
 	dh $@
 
 override_dh_install:
-	./scripts/fetch-and-run-installer.sh "1.80.0" "/usr" "debian/tmp" $(DEB_HOST_GNU_CPU)
+	./scripts/fetch-and-run-installer.sh "1.83.0" "/usr" "debian/tmp" $(DEB_HOST_GNU_CPU)
 
 	dh_install --autodest "debian/tmp/*"
 


### PR DESCRIPTION
# Problem: 

zfs pre-push runs (and ab-pre-push) have been failing with this:
```
00:44:20  error: failed to compile `cargo-bundle-licenses v2.0.0`, intermediate artifacts can be found at `/tmp/cargo-install8a5GKO`.
00:44:20  To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
00:44:20  
00:44:20  Caused by:
00:44:20    rustc 1.80.0 is not supported by the following package:
00:44:20      home@0.5.11 requires rustc 1.81
00:44:20    Try re-running `cargo install` with `--locked`
00:44:20  [1m[31mError: failed command 'cargo install cargo-bundle-licenses'(B[m
```
We need to upgrade rust tools to the latest stable version 1.83.0.

# Solution:

Upgrade rust tools to version 1.83.0.

See: PR for delphix/zfs repo: https://www.github.com/delphix/zfs/pull/1955

# Testing

https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10074/ RUNNING