### PR TITLE
DLPX-93311 24.04 LTS upgrade: kernel builds continue to fail due to rustc conflict

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Standards-Version: 4.1.2
 
 Package: delphix-rust
 Architecture: any
-Provides: cargo, rust-gdb, rustc
+Provides: cargo, rust-gdb, rustc (= ${binary:Version})
 Conflicts: cargo, rust-gdb, rustc
 Description: Rust - A programming language empowering everyone to build
   reliable and efficient software.


### PR DESCRIPTION
## Problem
#21 failed to resolve a dependency conflict that was seen while building the kernel packages on 24.04. The latest build failures still show the same conflict:
```
19:58:06  Starting 2 pkgProblemResolver with broken count: 1
19:58:06  Investigating (0) delphix-rust:amd64 < 1.80.0-1delphix.2025.01.31.14.59 @ii K Ib >
19:58:06  Broken delphix-rust:amd64 Conflicts on rustc:amd64 < none -> 1.75.0+dfsg0ubuntu1-0ubuntu7.1 @un uN >
19:58:06    Considering rustc:amd64 -1 as a solution to delphix-rust:amd64 1
19:58:06    Added rustc:amd64 to the remove list
19:58:06    Conflicts//Breaks against version 1.75.0+dfsg0ubuntu1-0ubuntu7 for rustc but that is not InstVer, ignoring
19:58:06    Conflicts//Breaks against version 1.74.1+dfsg0ubuntu1-0ubuntu13 for rustc-1.74 but that is not InstVer, ignoring
19:58:06    Fixing delphix-rust:amd64 via keep of rustc:amd64
19:58:06  Investigating (0) bindgen-0.65:amd64 < none -> 0.65.1+dfsg0-0ubuntu1 @un uN Ib >
19:58:06  Broken bindgen-0.65:amd64 Depends on rustc:amd64 < none | 1.75.0+dfsg0ubuntu1-0ubuntu7.1 @un uH > (>= 1.72.0+dfsg)
19:58:06    Considering rustc:amd64 -1 as a solution to bindgen-0.65:amd64 0
19:58:06    Holding Back bindgen-0.65:amd64 rather than change rustc:amd64
19:58:06  Investigating (0) linux-build-deps:amd64 < 6.8.0-47.47 @iU K Nb Ib >
19:58:06  Broken linux-build-deps:amd64 Depends on bindgen-0.65:amd64 < none | 0.65.1+dfsg0-0ubuntu1 @un uH >
19:58:06    Considering bindgen-0.65:amd64 0 as a solution to linux-build-deps:amd64 -2
19:58:06    Removing linux-build-deps:amd64 rather than change bindgen-0.65:amd64
19:58:06  Done
```
I believe the problem here is that the version of the `rustc` package is not specified by our `delphix-rust` virtual package based on this line:
```
19:58:06  Investigating (0) delphix-rust:amd64 < 1.80.0-1delphix.2025.01.31.14.59 @ii K Ib >
19:58:06  Broken delphix-rust:amd64 Conflicts on rustc:amd64 < none -> 1.75.0+dfsg0ubuntu1-0ubuntu7.1 @un uN >
```
I believe the problem is:
- bindgen-0.65 requires rustc (>= 1.72.0+dfsg)
- Our `delphix-rust`'s `Provides: rustc` doesn't specify a version
- Without a version in the `Provides:` field, apt doesn't know if `delphix-rust` satisfies the version requirement (hence the `none`)
- So apt tries to install a version of `rustc` to satisfy `bindgen-0.65`'s requirement of `rustc (>= 1.72.0+dfsg),`. The Ubuntu repos host version `1.75`
- But that in turn conflicts with our `delphix-rust`.


## Solution
To solve this, I would like to try and specify a version of the `rustc` and set it to be equal to the version of `delphix-rust` itself so that the dependency resolver can perform version comparisons and not install `rustc` from other sources.

## Testing
https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/delphix-rust/job/pre-push/65/console

```
delphix@ip-10-110-197-95:~$ aws s3 cp s3://dev-de-images/builds/jenkins-ops/linux-pkg/os-upgrade/build-package/delphix-rust/pre-push/65/delphix-rust_1.80.0-1delphix.2025.02.06.19.05_amd64.deb .
download: s3://dev-de-images/builds/jenkins-ops/linux-pkg/os-upgrade/build-package/delphix-rust/pre-push/65/delphix-rust_1.80.0-1delphix.2025.02.06.19.05_amd64.deb to ./delphix-rust_1.80.0-1delphix.2025.02.06.19.05_amd64.deb

delphix@ip-10-110-197-95:~$ dpkg-deb -R delphix-rust_1.80.0-1delphix.2025.02.06.19.05_amd64.deb tmp

delphix@ip-10-110-197-95:~$ grep Provides tmp/DEBIAN/control
Provides: cargo, rust-gdb, rustc (= 1.80.0-1delphix.2025.02.06.19.05)
```

More testing can only be done after a buildserver with these changes is built & imported.